### PR TITLE
Ignore "from" and npm-registry "resolved" keys

### DIFF
--- a/lib/clingwrap.js
+++ b/lib/clingwrap.js
@@ -74,7 +74,7 @@ clingwrap.sync = function (src, dest, packages) {
 clingwrap.npmbegone = function (pkginfo) {
   if (!pkginfo) { return }
   ['from', 'resolved'].forEach(function (key) {
-    if (pkginfo[key] && /registry\.npmjs\.org/.test(pkginfo[key]))
+    if (key === 'from' || /registry\.npmjs\.org/.test(pkginfo[key]))
       delete pkginfo[key]
   })
 

--- a/lib/clingwrap.js
+++ b/lib/clingwrap.js
@@ -26,11 +26,20 @@ clingwrap.loadExisting = function (cb) {
   })
 }
 
+function ignoreFromAndNpmResolved (key, value) {
+  if (value && value.dependencies) {
+    if (key === 'from' || /registry\.npmjs\.org/.test(value)) {
+      return undefined;
+    }
+  }
+  return value;
+}
+
 clingwrap.write = function (pkginfo, cb) {
   npm.load(function (err) {
     if (err) return cb(err)
     var file = path.resolve(npm.prefix, 'npm-shrinkwrap.json')
-    var data = JSON.stringify(pkginfo, null, 2) + "\n"
+    var data = JSON.stringify(pkginfo, ignoreFromAndNpmResolved, 2) + "\n"
     fs.writeFile(file, data, cb)
   })
 }

--- a/lib/clingwrap.js
+++ b/lib/clingwrap.js
@@ -28,6 +28,7 @@ clingwrap.loadExisting = function (cb) {
 
 function ignoreFromAndNpmResolved (key, value) {
   if (value && value.dependencies) {
+    // work only on a package object (from, version, dependencies, ...)
     if (key === 'from' || /registry\.npmjs\.org/.test(value)) {
       return undefined;
     }

--- a/test/clingwrap.test.coffee
+++ b/test/clingwrap.test.coffee
@@ -16,6 +16,11 @@ describe 'clingwrap', ->
           "version": "22.22.22",
           "from": "git+https://github.com/octocat/cookie.git#001643ca951583caa58a9134a245080c62b6f06e"
           "resolved": "git+https://github.com/octocat/cookie.git#001643ca951583caa58a9134a245080c62b6f06e"
+        },
+        "npm": {
+          "version": "2.13.5",
+          "from": "npm@2.13.5",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-2.13.5.tgz"
         }
       }
     }
@@ -24,11 +29,18 @@ describe 'clingwrap', ->
     beforeEach ->
       clingwrap.npmbegone shrinkwrap
 
-    it 'removes "from" and "resolved" keys pointing to registry.npmjs.org', ->
+    it 'removes "resolved" key pointing to registry.npmjs.org', ->
       shrinkwrap.dependencies.async.should.not.have.property 'resolved'
-      shrinkwrap.dependencies.async.should.not.have.property 'from'
-
-    it 'preserves "from" and "resolved" keys pointing elsewhere', ->
+      shrinkwrap.dependencies.octocat.should.have.property 'resolved'
       shrinkwrap.dependencies.octocat.resolved.should.match /github/
-      shrinkwrap.dependencies.octocat.from.should.match /github/
+      shrinkwrap.dependencies.npm.should.not.have.property 'resolved'
 
+    it 'removes "from"', ->
+      shrinkwrap.dependencies.async.should.not.have.property 'from'
+      shrinkwrap.dependencies.octocat.should.not.have.property 'from'
+      shrinkwrap.dependencies.npm.should.not.have.property 'from'
+
+    it 'preserves "version" key with whatever value it has', ->
+      shrinkwrap.dependencies.async.should.have.property 'version'
+      shrinkwrap.dependencies.octocat.should.have.property 'version'
+      shrinkwrap.dependencies.npm.should.have.property 'version'


### PR DESCRIPTION
Let's make the diffs even smaller, because npm generates lines as seen below:

```js
"async": {
  "version": "0.1.22",
  "from": "async@>=0.1.22 <0.2.0"
}
```
whereas the updated version does a better job here with ignoring the `from` key too.
```js
"async": {
  "version": "0.1.22"
}
```

GitHub / Private-Repositories are untouched thanks to `resolved` containing the direct URL to the tgz file.